### PR TITLE
Feat: Add optional stepsize to sliders

### DIFF
--- a/src/fieldArguments/inputFieldArguments/InputFieldArgumentFactory.ts
+++ b/src/fieldArguments/inputFieldArguments/InputFieldArgumentFactory.ts
@@ -13,12 +13,14 @@ import { DefaultValueInputFieldArgument } from './arguments/DefaultValueInputFie
 import { PlaceholderInputFieldArgument } from './arguments/PlaceholderInputFieldArgument';
 import { InputFieldArgumentType } from '../../parsers/inputFieldParser/InputFieldConfigs';
 import { UseLinksInputFieldArgument } from './arguments/UseLinksInputFieldArgument';
+import { StepSizeValueInputFieldArgument } from './arguments/StepSizeValueInputFieldArgument';
 
 export const INPUT_FIELD_ARGUMENT_MAP = {
 	[InputFieldArgumentType.CLASS]: ClassInputFieldArgument,
 	[InputFieldArgumentType.ADD_LABELS]: AddLabelsInputFieldArgument,
 	[InputFieldArgumentType.MIN_VALUE]: MinValueInputFieldArgument,
 	[InputFieldArgumentType.MAX_VALUE]: MaxValueInputFieldArgument,
+	[InputFieldArgumentType.STEP_SIZE]: StepSizeValueInputFieldArgument,
 	[InputFieldArgumentType.OPTION]: OptionInputFieldArgument,
 	[InputFieldArgumentType.TITLE]: TitleInputFieldArgument,
 	[InputFieldArgumentType.OPTION_QUERY]: OptionQueryInputFieldArgument,

--- a/src/fieldArguments/inputFieldArguments/arguments/MaxValueInputFieldArgument.ts
+++ b/src/fieldArguments/inputFieldArguments/arguments/MaxValueInputFieldArgument.ts
@@ -7,7 +7,7 @@ export class MaxValueInputFieldArgument extends AbstractInputFieldArgument {
 	value: number = 100;
 
 	_parseValue(value: ParsingResultNode[]): void {
-		this.value = Number.parseInt(value[0].value);
+		this.value = Number.parseFloat(value[0].value);
 		if (Number.isNaN(this.value)) {
 			throw new MetaBindParsingError(
 				ErrorLevel.ERROR,

--- a/src/fieldArguments/inputFieldArguments/arguments/MinValueInputFieldArgument.ts
+++ b/src/fieldArguments/inputFieldArguments/arguments/MinValueInputFieldArgument.ts
@@ -7,7 +7,7 @@ export class MinValueInputFieldArgument extends AbstractInputFieldArgument {
 	value: number = 0;
 
 	_parseValue(value: ParsingResultNode[]): void {
-		this.value = Number.parseInt(value[0].value);
+		this.value = Number.parseFloat(value[0].value);
 		if (Number.isNaN(this.value)) {
 			throw new MetaBindParsingError(
 				ErrorLevel.ERROR,

--- a/src/fieldArguments/inputFieldArguments/arguments/StepSizeValueInputFieldArgument.ts
+++ b/src/fieldArguments/inputFieldArguments/arguments/StepSizeValueInputFieldArgument.ts
@@ -1,0 +1,31 @@
+import { AbstractInputFieldArgument } from '../AbstractInputFieldArgument';
+import { ErrorLevel, MetaBindParsingError } from '../../../utils/errors/MetaBindErrors';
+import { type InputFieldArgumentConfig, InputFieldArgumentConfigs } from '../../../parsers/inputFieldParser/InputFieldConfigs';
+import { type ParsingResultNode } from '../../../parsers/nomParsers/GeneralParsers';
+
+export class StepSizeValueInputFieldArgument extends AbstractInputFieldArgument {
+	value: number = 0;
+
+	_parseValue(value: ParsingResultNode[]): void {
+		this.value = Number.parseFloat(value[0].value);
+		if (Number.isNaN(this.value)) {
+			throw new MetaBindParsingError(
+				ErrorLevel.WARNING,
+				'failed to set value for input field argument',
+				"value of argument 'stepSize' must be of type number",
+			);
+		}
+		if (this.value <= 0) {
+			throw new MetaBindParsingError(
+				ErrorLevel.WARNING,
+				'failed to set value for input field argument',
+				"value of argument 'stepSize' must be a positive number",
+			);
+
+		}
+	}
+
+	public getConfig(): InputFieldArgumentConfig {
+		return InputFieldArgumentConfigs.stepSize;
+	}
+}

--- a/src/inputFields/_new/fields/Slider/SliderComponent.svelte
+++ b/src/inputFields/_new/fields/Slider/SliderComponent.svelte
@@ -2,6 +2,7 @@
 	export let value: number;
 	export let minValue: number;
 	export let maxValue: number;
+	export let stepSize: number;
 	export let addLabels: boolean;
 	export let onValueChange: (value: number) => void;
 
@@ -12,11 +13,11 @@
 
 {#if addLabels}
 	<span class='meta-bind-plugin-slider-input-label'>{minValue}</span>
-	<input type='range' tabindex='0' min={minValue} max={maxValue} bind:value={value}
+	<input type='range' tabindex='0' min={minValue} max={maxValue} step={stepSize} bind:value={value}
 		   on:input={() => onValueChange(value)}>
 	<span class='meta-bind-plugin-slider-input-label'>{maxValue}</span>
 {:else}
-	<input type='range' tabindex='0' min={minValue} max={maxValue} bind:value={value}
+	<input type='range' tabindex='0' min={minValue} max={maxValue} step={stepSize} bind:value={value}
 		   on:input={() => onValueChange(value)}>
 {/if}
 

--- a/src/inputFields/_new/fields/Slider/SliderIPF.ts
+++ b/src/inputFields/_new/fields/Slider/SliderIPF.ts
@@ -8,12 +8,15 @@ import { InputFieldArgumentType } from '../../../../parsers/inputFieldParser/Inp
 export class SliderIPF extends NewAbstractInputField<number, number> {
 	minValue: number;
 	maxValue: number;
+	stepSize: number;
 
 	constructor(renderChild: InputFieldMDRC) {
 		super(renderChild);
 
+		// FIXME: Check that minvalue < maxvalue.
 		this.minValue = this.renderChild.getArgument(InputFieldArgumentType.MIN_VALUE)?.value ?? 0;
 		this.maxValue = this.renderChild.getArgument(InputFieldArgumentType.MAX_VALUE)?.value ?? 100;
+		this.stepSize = this.renderChild.getArgument(InputFieldArgumentType.STEP_SIZE)?.value ?? 1;
 	}
 
 	protected filterValue(value: any): number | undefined {
@@ -51,6 +54,7 @@ export class SliderIPF extends NewAbstractInputField<number, number> {
 		return {
 			minValue: this.minValue,
 			maxValue: this.maxValue,
+			stepSize: this.stepSize,
 			addLabels: this.renderChild.getArgument(InputFieldArgumentType.ADD_LABELS)?.value === true,
 		};
 	}

--- a/src/parsers/inputFieldParser/InputFieldConfigs.ts
+++ b/src/parsers/inputFieldParser/InputFieldConfigs.ts
@@ -30,6 +30,7 @@ export enum InputFieldArgumentType {
 	ADD_LABELS = 'addLabels',
 	MIN_VALUE = 'minValue',
 	MAX_VALUE = 'maxValue',
+	STEP_SIZE = 'stepSize',
 	OPTION = 'option',
 	TITLE = 'title',
 	OPTION_QUERY = 'optionQuery',
@@ -226,6 +227,20 @@ export const InputFieldArgumentConfigs: Record<InputFieldArgumentType, InputFiel
 					name: 'value',
 					allowed: ['number'],
 					description: 'the minimally allowed value',
+				},
+			],
+		],
+		allowMultiple: false,
+	},
+	[InputFieldArgumentType.STEP_SIZE]: {
+		type: InputFieldArgumentType.STEP_SIZE,
+		allowedFieldTypes: [InputFieldType.SLIDER],
+		values: [
+			[
+				{
+					name: 'value',
+					allowed: ['number'],
+					description: 'the step size for sliders',
 				},
 			],
 		],


### PR DESCRIPTION
Adds a `stepSize(number)` argument to the Slider component, implementing https://github.com/mProjectsCode/obsidian-meta-bind-plugin/issues/110.

Example usage:

```
INPUT[slider(addLabels, minValue(0), maxValue(100), stepSize(20)):slider]
```