### PR TITLE
Fix underline position in error message

### DIFF
--- a/src/parsers/ParsingError.ts
+++ b/src/parsers/ParsingError.ts
@@ -77,10 +77,10 @@ export class ParsingValidationError extends MetaBindError {
 			return '';
 		}
 
-		const spacing = ' '.repeat(this.position.from.index + offset);
+		const spacing = ' '.repeat(this.position.from.column + offset);
 		// highlight to the end if the end is on the same line. If the end is on a different line, highlight to the end of the line.
-		const toIndex = this.position.to.line === this.position.from.line ? this.position.to.index : lineLength;
-		const underline = '^'.repeat(toIndex - this.position.from.index);
+		const toIndex = this.position.to.line === this.position.from.line ? this.position.to.column : lineLength;
+		const underline = '^'.repeat(toIndex - this.position.from.column);
 
 		return spacing + underline;
 	}


### PR DESCRIPTION
Previously, this underline (`^^^^`) did not position correctly when writing your metabind code in a readable way (with newlines and tabs):

```
INPUT[slider(
	addLabels,
	minValue(0),
	maxValue(100),
	this_is_invalid_oh_no
):slider]
```

This fix makes it underline at the correction position as shown in the image below.

![image](https://github.com/mProjectsCode/obsidian-meta-bind-plugin/assets/25849034/0c10ee76-49c2-4335-9a38-f8199e5f8f16)
