### PR TITLE
Update GeneralConfigs.ts

### DIFF
--- a/src/parsers/GeneralConfigs.ts
+++ b/src/parsers/GeneralConfigs.ts
@@ -424,7 +424,7 @@ export const InputFieldArgumentConfigs: Record<InputFieldArgumentType, InputFiel
 				{
 					name: 'value',
 					allowed: ['number'],
-					description: 'character limit for text fields',
+					description: 'a character limit for text fields',
 				},
 			],
 		],


### PR DESCRIPTION
This single letter ensures that documentation displayed at <https://mprojectscode.github.io/obsidian-meta-bind-plugin-docs/reference/inputfieldarguments/limit/> does not have a typo :^)