### PR TITLE
Add option for relative to button line insert into note

### DIFF
--- a/packages/core/src/config/ButtonConfig.ts
+++ b/packages/core/src/config/ButtonConfig.ts
@@ -92,6 +92,7 @@ export interface RegexpReplaceInNoteButtonAction {
 
 export interface InsertIntoNoteButtonAction {
 	type: ButtonActionType.INSERT_INTO_NOTE;
+	relative: boolean;
 	line: number;
 	value: string;
 	templater?: boolean;

--- a/packages/core/src/config/ButtonConfigValidators.ts
+++ b/packages/core/src/config/ButtonConfigValidators.ts
@@ -145,6 +145,11 @@ export const V_RegexpReplaceInNoteButtonAction = schemaForType<RegexpReplaceInNo
 export const V_InsertIntoNoteButtonAction = schemaForType<InsertIntoNoteButtonAction>()(
 	z.object({
 		type: z.literal(ButtonActionType.INSERT_INTO_NOTE),
+		relative: booleanValidator(
+			'insertIntoNote',
+			'relative',
+			'value for whether the line number is relative to the button',
+		),
 		line: numberValidator('insertIntoNote', 'line', 'line to insert at'),
 		value: stringValidator('insertIntoNote', 'value', 'string to insert'),
 		templater: booleanValidator('insertIntoNote', 'templater', 'value for whether to use Templater').optional(),

--- a/packages/core/src/fields/button/ButtonActionRunner.ts
+++ b/packages/core/src/fields/button/ButtonActionRunner.ts
@@ -419,12 +419,13 @@ export class ButtonActionRunner {
 				insertString,
 				...splitContent.slice(linePosition.lineStart + action.line + 1),
 			];
-		} else
+		} else {
 			splitContent = [
 				...splitContent.slice(0, action.line - 1),
 				insertString,
 				...splitContent.slice(action.line - 1),
 			];
+		}
 
 		await this.plugin.internal.writeFilePath(filePath, splitContent.join('\n'));
 	}

--- a/packages/core/src/modals/modalContents/buttonBuilder/InsertIntoNoteActionSettings.svelte
+++ b/packages/core/src/modals/modalContents/buttonBuilder/InsertIntoNoteActionSettings.svelte
@@ -3,10 +3,15 @@
 	import Button from 'packages/core/src/utils/components/Button.svelte';
 	import SettingComponent from 'packages/core/src/utils/components/SettingComponent.svelte';
 	import { IPlugin } from 'packages/core/src/IPlugin';
+	import Toggle from 'packages/core/src/utils/components/Toggle.svelte';
 
 	export let action: InsertIntoNoteButtonAction;
 	export let plugin: IPlugin;
 </script>
+
+<SettingComponent name="Relative" description="Whether the line number is relative to the button.">
+	<Toggle bind:checked={action.relative}></Toggle>
+</SettingComponent>
 
 <SettingComponent name="Line" description="The line number to insert at.">
 	<input type="number" bind:value={action.line} placeholder="0" />

--- a/tests/fields/Button.test.ts
+++ b/tests/fields/Button.test.ts
@@ -214,6 +214,7 @@ const buttonActionTests: Record<ButtonActionType, () => void> = {
 
 			await simplifiedRunAction({
 				type: ButtonActionType.INSERT_INTO_NOTE,
+				relative: false,
 				line: 2,
 				value: 'newLine2',
 			});


### PR DESCRIPTION
Part solution for issue #296.

Enables prepending and appending content in relation to the button. A toggle inside the `insertIntoNote` action now enables/disables the relative option.

On disable the functionality is all the same.

On enable it allows values below `0`; a `-1` for example will add the content directly in front of the button. A `1` would add it directly behind it. 
Employs the position parameter and it's relevant `.getPosition()` function.

Extended the respective test by adding the new variable. It is only set to false and I haven't (yet) added a new test case that would correctly test the new functionality automatically. I did test it manually though...
Running `bun run test` successfully completed.

`bun run check` led to an error as it couldn't find the package `prettier-plugin-svelte`. But this error already occurred before I changed anything so I figured it may not be due to my changes. Possibly it's something on my machine but I'm not sure. The file it tries to import it from `.\obsidian-meta-bind-plugin\noop.js` doesn't exist either.
My apologies if it's an error on my part.