### PR TITLE
Add `mathjs` singleton and expose it via API

### DIFF
--- a/packages/core/src/api/API.ts
+++ b/packages/core/src/api/API.ts
@@ -1,3 +1,4 @@
+import type { ImportObject as MathJSImportObject, ImportOptions as MathJSImportOptions } from 'mathjs';
 import { SyntaxHighlightingAPI } from 'packages/core/src/api/SyntaxHighlightingAPI';
 import type {
 	ButtonGroupOptions,
@@ -826,5 +827,13 @@ export abstract class API<Plugin extends IPlugin> {
 			lineStart: lineStart,
 			lineEnd: lineEnd,
 		});
+	}
+
+	/**
+	 * Import new definitions into the internal mathJS instance.
+	 * For details on how to use, see https://mathjs.org/docs/reference/functions/import.html
+	 */
+	public mathJSimport(object: MathJSImportObject | MathJSImportObject[], options?: MathJSImportOptions): void {
+		this.plugin.internal.math.import(object, options);
 	}
 }

--- a/packages/core/src/api/InternalAPI.ts
+++ b/packages/core/src/api/InternalAPI.ts
@@ -1,3 +1,4 @@
+import type { MathJsInstance } from 'mathjs';
 import type { Moment } from 'moment';
 import type { LifecycleHook } from 'packages/core/src/api/API';
 import type { FileAPI } from 'packages/core/src/api/FileAPI';
@@ -28,6 +29,7 @@ import type { ContextMenuItemDefinition, IContextMenu } from 'packages/core/src/
 import type { IFuzzySearch } from 'packages/core/src/utils/IFuzzySearch';
 import type { IJsRenderer } from 'packages/core/src/utils/IJsRenderer';
 import type { MBLiteral } from 'packages/core/src/utils/Literal';
+import { createMathJS } from 'packages/core/src/utils/MathJS';
 import { mount, unmount } from 'svelte';
 import type { z } from 'zod';
 
@@ -75,10 +77,12 @@ export const IMAGE_FILE_EXTENSIONS_WITH_DOTS = IMAGE_FILE_EXTENSIONS.map(ext => 
 export abstract class InternalAPI<Plugin extends IPlugin> {
 	readonly plugin: Plugin;
 	readonly file: FileAPI<Plugin>;
+	readonly math: MathJsInstance;
 
 	constructor(plugin: Plugin, fileAPI: FileAPI<Plugin>) {
 		this.plugin = plugin;
 		this.file = fileAPI;
+		this.math = createMathJS();
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/core/src/fields/viewFields/fields/MathVF.ts
+++ b/packages/core/src/fields/viewFields/fields/MathVF.ts
@@ -1,5 +1,4 @@
 import type { EvalFunction } from 'mathjs';
-import { compile as MathJsCompile } from 'mathjs';
 import { AbstractViewField } from 'packages/core/src/fields/viewFields/AbstractViewField';
 import type { ViewFieldMountable } from 'packages/core/src/fields/viewFields/ViewFieldMountable';
 import type { ViewFieldVariable } from 'packages/core/src/fields/viewFields/ViewFieldVariable';
@@ -50,7 +49,7 @@ export class MathVF extends AbstractViewField<MathVFResult> {
 			}
 		}
 
-		this.expression = MathJsCompile(this.expressionStr);
+		this.expression = this.plugin.internal.math.compile(this.expressionStr);
 	}
 
 	private buildMathJSContext(): Record<string, unknown> {

--- a/packages/core/src/utils/MathJS.ts
+++ b/packages/core/src/utils/MathJS.ts
@@ -1,0 +1,9 @@
+import type { MathJsInstance, ConfigOptions } from 'mathjs';
+import { create as MathJSCreate, all } from 'mathjs';
+
+export function createMathJS(): MathJsInstance {
+	// TODO: we should probably limit the functionality of MathJS
+	// we don't need full support for matrices, big numbers and all the other high level stuff
+	const options: ConfigOptions = {};
+	return MathJSCreate(all, options);
+}


### PR DESCRIPTION
This allows for modification of `mathjs` by the user, mostly to allow for the use of `math.import` to define custom functions.

See the new `Advanced Examples/Customising mathjs` for details.

closes #480 

---

This is a first implementation, it works but I am sure there are better ways to implement the singleton.
Finding the right place in the lifecycle of the app just went over my head

I am also unsure if the `MathjsInstance` should be per-app or per file?