### PR TITLE
Feat: tooltip for INPUT[slider]

### DIFF
--- a/packages/core/src/fields/inputFields/fields/ProgressBar/ProgressBarComponent.svelte
+++ b/packages/core/src/fields/inputFields/fields/ProgressBar/ProgressBarComponent.svelte
@@ -111,8 +111,9 @@
 <div
 	class="mb-progress-bar-input"
 	tabindex="0"
-	bind:this={progressBarEl}
 	role="button"
+	aria-label={value.toString()}
+	bind:this={progressBarEl}
 	onkeydown={onKeyPress}
 	onmousedown={onTrackEvent}
 	ontouchstart={onTrackEvent}
@@ -125,7 +126,6 @@
 		aria-valuemin={props.minValue}
 		aria-valuemax={props.maxValue}
 		aria-valuenow={value}
-		aria-label={value.toString()}
 		tabindex="0"
 	></div>
 	{#if props.addLabels}

--- a/packages/core/src/fields/inputFields/fields/Slider/SliderComponent.svelte
+++ b/packages/core/src/fields/inputFields/fields/Slider/SliderComponent.svelte
@@ -22,6 +22,7 @@
 	class="mb-slider-input slider"
 	type="range"
 	tabindex="0"
+	aria-label={value.toString()}
 	min={props.minValue}
 	max={props.maxValue}
 	step={props.stepSize}


### PR DESCRIPTION
This PR implements the on-hover tooltip for the `INPUT[slider]` object, similiar to how it was added to the `INPUT[progressBar]` in #473.

When hovering the input, a small tooltip will be displayes under the center of the slider showing the current value.

----

I also modified the on-hover behavior of the progress bar to make the two components consisten. 

Previously one had to hover over teh "filled" part of the progressbar and the tooltip woud be centered on that part. 

Now the label is on the conctainer. That means both components can now be consitently be hovered anywhere and will get the tooltip.

----

### Testing

test it using:

````md
---
exampleProperty: 13
---

```meta-bind
INPUT[slider(addLabels):exampleProperty]
```

```meta-bind
INPUT[progressBar:exampleProperty]
```
````