### PR TITLE
OpenButton Action PaneType matches obsidian option

### DIFF
--- a/packages/core/src/api/FileAPI.ts
+++ b/packages/core/src/api/FileAPI.ts
@@ -3,6 +3,7 @@ import { MDLinkParser } from 'packages/core/src/parsers/MarkdownLinkParser';
 import { ErrorLevel, MetaBindParsingError } from 'packages/core/src/utils/errors/MetaBindErrors';
 import type { LineNumberContext } from 'packages/core/src/utils/LineNumberExpression';
 import type { MB_Comps, MetaBind } from '..';
+import type { ButtonPaneType } from '../config/ButtonConfig';
 
 export abstract class FileAPI<Components extends MB_Comps> {
 	readonly mb: MetaBind<Components>;
@@ -57,9 +58,9 @@ export abstract class FileAPI<Components extends MB_Comps> {
 	 *
 	 * @param filePath
 	 * @param callingFilePath
-	 * @param newTab
+	 * @param PaneType
 	 */
-	public abstract open(filePath: string, callingFilePath: string, newTab: boolean): Promise<void>;
+	public abstract open(filePath: string, callingFilePath: string, PaneType: ButtonPaneType | boolean): Promise<void>;
 
 	/**
 	 * Resolves a file name to a file path.

--- a/packages/core/src/config/ButtonConfig.ts
+++ b/packages/core/src/config/ButtonConfig.ts
@@ -36,6 +36,12 @@ export enum ButtonActionType {
 	INLINE_JS = 'inlineJS',
 }
 
+export enum ButtonPaneType {
+	NewTab = 'tab',
+	NewSplit = 'split',
+	NewWindow = 'window',
+}
+
 export interface CommandButtonAction {
 	type: ButtonActionType.COMMAND;
 	command: string;
@@ -50,7 +56,7 @@ export interface JSButtonAction {
 export interface OpenButtonAction {
 	type: ButtonActionType.OPEN;
 	link: string;
-	newTab?: boolean;
+	panetype?: ButtonPaneType; // "tab" | "split" | "window"
 }
 
 export interface InputButtonAction {
@@ -232,6 +238,14 @@ export class ButtonClickContext {
 	 */
 	openInNewTab(): boolean {
 		return this.type === ButtonClickType.MIDDLE || this.ctrlKey;
+	}
+
+	openInNewWindow(): boolean {
+		return this.type === ButtonClickType.LEFT && this.ctrlKey && this.altKey && this.shiftKey;
+	}
+
+	openInNewSplit(): boolean {
+		return this.type === ButtonClickType.MIDDLE && this.ctrlKey && this.altKey;
 	}
 }
 

--- a/packages/core/src/config/validators/ButtonConfigValidators.ts
+++ b/packages/core/src/config/validators/ButtonConfigValidators.ts
@@ -16,7 +16,7 @@ import type {
 	TemplaterCreateNoteButtonAction,
 	UpdateMetadataButtonAction,
 } from 'packages/core/src/config/ButtonConfig';
-import { ButtonActionType, ButtonStyleType } from 'packages/core/src/config/ButtonConfig';
+import { ButtonActionType, ButtonPaneType, ButtonStyleType } from 'packages/core/src/config/ButtonConfig';
 import { oneOf, schemaForType } from 'packages/core/src/utils/ZodUtils';
 import { z } from 'zod';
 
@@ -91,7 +91,7 @@ export const V_OpenButtonAction = schemaForType<OpenButtonAction>()(
 	z.object({
 		type: z.literal(ButtonActionType.OPEN),
 		link: actionFieldString('open', 'link', 'link to open'),
-		newTab: actionFieldBool('open', 'newTab', '').optional(),
+		panetype: z.enum([ButtonPaneType.NewTab, ButtonPaneType.NewSplit, ButtonPaneType.NewWindow]).optional(),
 	}),
 );
 

--- a/packages/core/src/fields/button/actions/OpenButtonActionConfig.ts
+++ b/packages/core/src/fields/button/actions/OpenButtonActionConfig.ts
@@ -1,13 +1,15 @@
 import type { MetaBind } from 'packages/core/src';
-import type {
-	ButtonClickContext,
-	ButtonConfig,
-	ButtonContext,
-	OpenButtonAction,
+import {
+	type ButtonClickContext,
+	type ButtonConfig,
+	type ButtonContext,
+	type OpenButtonAction,
+	ButtonPaneType,
 } from 'packages/core/src/config/ButtonConfig';
 import { ButtonActionType } from 'packages/core/src/config/ButtonConfig';
 import { AbstractButtonActionConfig } from 'packages/core/src/fields/button/AbstractButtonActionConfig';
 import { MDLinkParser } from 'packages/core/src/parsers/MarkdownLinkParser';
+import Button from 'packages/core/src/utils/components/Button.svelte';
 
 export class OpenButtonActionConfig extends AbstractButtonActionConfig<OpenButtonAction> {
 	constructor(mb: MetaBind) {
@@ -21,16 +23,27 @@ export class OpenButtonActionConfig extends AbstractButtonActionConfig<OpenButto
 		_context: ButtonContext,
 		click: ButtonClickContext,
 	): Promise<void> {
-		const newTab = click.openInNewTab() || (action.newTab ?? false);
 		const link = MDLinkParser.interpretAsLink(action.link);
 		if (!link) {
 			throw new Error('Invalid link');
 		}
-		link.open(this.mb, filePath, newTab);
+
+		let pane: ButtonPaneType | boolean | undefined = action.panetype;
+		if (click.openInNewSplit()) {
+			pane = ButtonPaneType.NewSplit;
+		}
+		if (click.openInNewTab()) {
+			pane = ButtonPaneType.NewTab;
+		}
+		if (click.openInNewWindow()) {
+			pane = ButtonPaneType.NewWindow;
+		}
+
+		link.open(this.mb, filePath, pane ?? (undefined as unknown as ButtonPaneType));
 	}
 
 	create(): Required<OpenButtonAction> {
-		return { type: ButtonActionType.OPEN, link: '', newTab: true };
+		return { type: ButtonActionType.OPEN, link: '', panetype: ButtonPaneType.NewTab };
 	}
 
 	getActionLabel(): string {

--- a/packages/core/src/modals/modalContents/buttonBuilder/OpenActionSettings.svelte
+++ b/packages/core/src/modals/modalContents/buttonBuilder/OpenActionSettings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { MetaBind } from 'packages/core/src';
-	import { ButtonStyleType, type OpenButtonAction } from 'packages/core/src/config/ButtonConfig';
+	import { ButtonStyleType, ButtonPaneType, type OpenButtonAction } from 'packages/core/src/config/ButtonConfig';
 
 	import Button from 'packages/core/src/utils/components/Button.svelte';
 	import Icon from 'packages/core/src/utils/components/Icon.svelte';
@@ -29,6 +29,11 @@
 	>
 </SettingComponent>
 
-<SettingComponent name="New tab" description="Whether to open the link in a new tab.">
-	<Toggle bind:checked={action.newTab}></Toggle>
+<SettingComponent name="Open in" description="How the link should open.">
+	<select bind:value={action.panetype}>
+		<option value={false}>Same Tab</option>
+		<option value={ButtonPaneType.NewTab}>New Tab</option>
+		<option value={ButtonPaneType.NewSplit}>New Split</option>
+		<option value={ButtonPaneType.NewWindow}>New Window</option>
+	</select>
 </SettingComponent>

--- a/packages/core/src/parsers/MarkdownLinkParser.ts
+++ b/packages/core/src/parsers/MarkdownLinkParser.ts
@@ -5,6 +5,7 @@ import { P_FilePath } from 'packages/core/src/parsers/nomParsers/GeneralNomParse
 import { runParser } from 'packages/core/src/parsers/ParsingError';
 import { isUrl, openURL } from 'packages/core/src/utils/Utils';
 import type { MetaBind } from '..';
+import type { ButtonPaneType } from '../config/ButtonConfig';
 
 const P_MDLinkInner: Parser<[string, string | undefined, string | undefined]> = P.sequence(
 	P_FilePath, // the file path
@@ -63,9 +64,9 @@ export class MarkdownLink {
 		return this.block ? `${this.target}#${this.block}` : this.target;
 	}
 
-	open(mb: MetaBind, relativeFilePath: string, newTab: boolean): void {
+	open(mb: MetaBind, relativeFilePath: string, PaneType: ButtonPaneType): void {
 		if (this.internal) {
-			void mb.file.open(this.fullTarget(), relativeFilePath, newTab);
+			void mb.file.open(this.fullTarget(), relativeFilePath, PaneType);
 		} else {
 			openURL(this.target);
 		}

--- a/packages/obsidian/src/ObsFileAPI.ts
+++ b/packages/obsidian/src/ObsFileAPI.ts
@@ -2,6 +2,7 @@ import type { App } from 'obsidian';
 import { normalizePath, TFile, TFolder } from 'obsidian';
 import { FileAPI } from 'packages/core/src/api/FileAPI';
 import type { ObsComponents, ObsMetaBind } from 'packages/obsidian/src/main';
+import type { ButtonPaneType } from './docsExports';
 
 export class ObsFileAPI extends FileAPI<ObsComponents> {
 	readonly app: App;
@@ -72,8 +73,8 @@ export class ObsFileAPI extends FileAPI<ObsComponents> {
 			.map(file => file.path);
 	}
 
-	public async open(filePath: string, callingFilePath: string, newTab: boolean): Promise<void> {
-		void this.app.workspace.openLinkText(filePath, callingFilePath, newTab);
+	public async open(filePath: string, callingFilePath: string, PaneType: ButtonPaneType): Promise<void> {
+		void this.app.workspace.openLinkText(filePath, callingFilePath, PaneType);
 	}
 
 	public async openInSourceMode(file: TFile, newTab: boolean): Promise<void> {

--- a/packages/publish/src/PublishFileAPI.ts
+++ b/packages/publish/src/PublishFileAPI.ts
@@ -1,4 +1,5 @@
 import { FileAPI } from 'packages/core/src/api/FileAPI';
+import type { ButtonPaneType } from 'packages/core/src/config/ButtonConfig';
 import type { PublishComponents } from 'packages/publish/src/main';
 
 export class PublishFileAPI extends FileAPI<PublishComponents> {
@@ -40,7 +41,7 @@ export class PublishFileAPI extends FileAPI<PublishComponents> {
 		return Array.from(folders);
 	}
 
-	public open(_filePath: string, _callingFilePath: string, _newTab: boolean): Promise<void> {
+	public open(_filePath: string, _callingFilePath: string, _paneType: ButtonPaneType | boolean): Promise<void> {
 		throw new Error('not implemented');
 	}
 

--- a/tests/fields/Button.test.ts
+++ b/tests/fields/Button.test.ts
@@ -4,6 +4,7 @@ import {
 	ButtonActionType,
 	ButtonClickContext,
 	ButtonClickType,
+	ButtonPaneType,
 } from 'packages/core/src/config/ButtonConfig';
 import { TestMetaBind } from 'tests/__mocks__/TestPlugin';
 
@@ -55,7 +56,7 @@ const buttonActionTests: Record<ButtonActionType, () => void> = {
 				await simplifiedRunAction({
 					type: ButtonActionType.OPEN,
 					link: '[[test/otherFile.md]]',
-					newTab: true,
+					panetype: ButtonPaneType.NewSplit,
 				});
 			}).not.toThrow();
 		});


### PR DESCRIPTION
Added PaneType enum option to open button actions to provide same options available in obisidan, same tab, new tab, new split, new window. 

<img width="378" height="94" alt="image" src="https://github.com/user-attachments/assets/20b65d74-140c-4fae-b0ba-21f376973a2f" />

The linter kept failing with File Name too long: but this is just a windows limitation
<img width="560" height="108" alt="image" src="https://github.com/user-attachments/assets/8485ecb0-f407-4eee-844a-e7318f7ffaa2" />
